### PR TITLE
Escapes strings with quote inside

### DIFF
--- a/src/Toastr.php
+++ b/src/Toastr.php
@@ -106,9 +106,21 @@ class Toastr
      */
     public function info($message, $title = null, $options = [])
     {
-        $this->add('info', $message, $title, $options);
-    }
+		if($message instanceof MessageBag)
+		{
+			$messageString = "";
+			foreach ($message->getMessages() as $messageArray)
+			{
+				foreach ($messageArray as $currentMessage)
+					$messageString .= $currentMessage."<br>";
+			}
 
+			$this->add('info', rtrim($messageString, "<br>"), $title, $options);
+		}
+		else
+			$this->add('info', $message, $title, $options);
+    }
+    
     /**
      * Add a success flash message to session.
      *
@@ -120,7 +132,19 @@ class Toastr
      */
     public function success($message, $title = null, $options = [])
     {
-        $this->add('success', $message, $title, $options);
+		if($message instanceof MessageBag)
+		{
+			$messageString = "";
+			foreach ($message->getMessages() as $messageArray)
+			{
+				foreach ($messageArray as $currentMessage)
+					$messageString .= $currentMessage."<br>";
+			}
+
+			$this->add('success', rtrim($messageString, "<br>"), $title, $options);
+		}
+		else
+			$this->add('success', $message, $title, $options);
     }
 
     /**
@@ -134,7 +158,19 @@ class Toastr
      */
     public function warning($message, $title = null, $options = [])
     {
-        $this->add('warning', $message, $title, $options);
+		if($message instanceof MessageBag)
+		{
+			$messageString = "";
+			foreach ($message->getMessages() as $messageArray)
+			{
+				foreach ($messageArray as $currentMessage)
+					$messageString .= $currentMessage."<br>";
+			}
+
+			$this->add('warning', rtrim($messageString, "<br>"), $title, $options);
+		}
+		else
+			$this->add('warning', $message, $title, $options);
     }
 
     /**
@@ -148,7 +184,19 @@ class Toastr
      */
     public function error($message, $title = null, $options = [])
     {
-        $this->add('error', $message, $title, $options);
+    	if($message instanceof MessageBag)
+		{
+			$messageString = "";
+			foreach ($message->getMessages() as $messageArray)
+			{
+				foreach ($messageArray as $currentMessage)
+					$messageString .= $currentMessage."<br>";
+			}
+
+			$this->add('error', rtrim($messageString, "<br>"), $title, $options);
+		}
+    	else
+        	$this->add('error', $message, $title, $options);
     }
 
     /**

--- a/src/Toastr.php
+++ b/src/Toastr.php
@@ -52,7 +52,7 @@ class Toastr
                $script .= 'toastr.options = ' . json_encode($config) . ';';
            }
 
-           $title = $message['title'] ?: null;
+           $title = addslashes($message['title']) ?: null;
 
             $script .= 'toastr.' . $message['type'] .
                 '(\'' . addslashes($message['message']) .

--- a/src/Toastr.php
+++ b/src/Toastr.php
@@ -4,6 +4,7 @@ namespace Brian2694\Toastr;
 
 use Illuminate\Session\SessionManager as Session;
 use Illuminate\Config\Repository as Config;
+use Illuminate\Support\MessageBag;
 
 class Toastr
 {

--- a/src/Toastr.php
+++ b/src/Toastr.php
@@ -55,7 +55,7 @@ class Toastr
            $title = $message['title'] ?: null;
 
             $script .= 'toastr.' . $message['type'] .
-                '(\'' . $message['message'] .
+                '(\'' . addslashes($message['message']) .
                 "','$title" .
                 '\');';
 


### PR DESCRIPTION
E.g. "It's ok, don't do it"  would error out "Uncaught SyntaxError: missing ) after argument list" and not display at all